### PR TITLE
LFLT-404 Domino cannot process configuration for disabled health-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domino",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "description": "Deployment Orchestration for Minor Infrastructures, powered by Node.js",
   "main": "src/domino_esm_start.js",
   "bin": "build/target/for_packaging/es5_src/domino_pkg_entry_point.js",
@@ -8,6 +8,7 @@
     "test": "env NODE_ENV=test mocha --require @babel/register --require @babel/polyfill test/**/*.js",
     "test_win": "set NODE_ENV=test&& mocha --require @babel/register --require @babel/polyfill test/**/*.js",
     "coverage": "nyc --all --reporter=html --report-dir=.nyc_output/coverage npm run test",
+    "coverage_win": "nyc --all --reporter=html --report-dir=.nyc_output/coverage npm run test_win",
     "start": "node src/domino_esm_start.js"
   },
   "pkg": {

--- a/src/domino/core/domain/AppRegistrationDomain.js
+++ b/src/domino/core/domain/AppRegistrationDomain.js
@@ -84,7 +84,7 @@ export class AppExecution {
 export class AppHealthCheck {
 
 	constructor(yamlSourceDocumentExecutionNode) {
-		if (yamlSourceDocumentExecutionNode) {
+		if (yamlSourceDocumentExecutionNode && yamlSourceDocumentExecutionNode["enabled"]) {
 			this.enabled = yamlSourceDocumentExecutionNode["enabled"];
 			this.delay = ms(yamlSourceDocumentExecutionNode["delay"]);
 			this.timeout = ms(yamlSourceDocumentExecutionNode["timeout"]);

--- a/src/domino/core/registration/RuntimeRegistrationsFactory.js
+++ b/src/domino/core/registration/RuntimeRegistrationsFactory.js
@@ -13,7 +13,7 @@ export default class RuntimeRegistrationsFactory {
 	 */
 	createRuntimeRegistrations(yamlSourceDocument) {
 
-		const runtimesNode = yamlSourceDocument["domino"]["runtimes"];
+		const runtimesNode = yamlSourceDocument["domino"]["runtimes"] || [];
 		const runtimes = runtimesNode
 			.map(this._createRuntimeRegistration)
 			.map(runtime => [runtime.runtimeName, runtime]);

--- a/test/domino/core/registration/AppRegistrationsFactoryTest.js
+++ b/test/domino/core/registration/AppRegistrationsFactoryTest.js
@@ -62,6 +62,9 @@ describe("Unit tests for AppRegistrationsFactory", () => {
 								"as-user": "tms-user",
 								via: "RUNTIME",
 								args: "arg3"
+							},
+							"health-check": {
+								enabled: false
 							}
 						}
 					}]

--- a/test/domino/core/registration/RuntimeRegistrationsFactoryTest.js
+++ b/test/domino/core/registration/RuntimeRegistrationsFactoryTest.js
@@ -47,5 +47,17 @@ describe("Unit tests for RuntimeRegistrationsFactory", () => {
 				resourceMarker: ""
 			});
 		});
+
+		it("should skip runtime registrations if missing", () => {
+
+			// given
+			const registrationsFile = {domino: {}};
+
+			// when
+			const result = runtimeRegistrationsFactory.createRuntimeRegistrations(registrationsFile);
+
+			// then
+			assert.equal(result.size, 0);
+		});
 	});
 });


### PR DESCRIPTION
 - Fixed runtime registration in case of missing definitions
 - Fixed application registration in case of explicitly disabled health-check
 - Aligned unit tests